### PR TITLE
new: optimize `BlockPos.iterateOutwards` by caching offsets

### DIFF
--- a/src/main/java/me/jellysquid/mods/lithium/common/cached_blockpos_iteration/IterateOutwardsCache.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/cached_blockpos_iteration/IterateOutwardsCache.java
@@ -1,0 +1,72 @@
+package me.jellysquid.mods.lithium.common.cached_blockpos_iteration;
+
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongList;
+import net.minecraft.util.math.BlockPos;
+
+import java.util.Iterator;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author 2No2Name, original implemenation by SuperCoder7979 and Gegy1000
+ */
+public class IterateOutwardsCache {
+    //POS_ZERO must not be replaced with BlockPos.ORIGIN, otherwise iterateOutwards at BlockPos.ORIGIN will not use the cache
+    public static final BlockPos POS_ZERO = new BlockPos(0,0,0);
+
+
+    private final ConcurrentHashMap<Long, LongArrayList> table;
+    private final int capacity;
+    private final Random random;
+
+    public IterateOutwardsCache(int capacity) {
+        this.capacity = capacity;
+        this.table = new ConcurrentHashMap<>(31);
+        this.random = new Random();
+    }
+
+    private void fillPositionsWithIterateOutwards(LongList entry, int xRange, int yRange, int zRange) {
+        // Add all positions to the cached list
+        for (BlockPos pos : BlockPos.iterateOutwards(POS_ZERO, xRange, yRange, zRange)) {
+            entry.add(pos.asLong());
+        }
+    }
+
+    public LongList getOrCompute(int xRange, int yRange, int zRange) {
+        long key = BlockPos.asLong(xRange, yRange, zRange);
+
+        LongArrayList entry = this.table.get(key);
+        if (entry != null) {
+            return entry;
+        }
+
+        // Cache miss: compute and store
+        entry = new LongArrayList(128);
+
+        this.fillPositionsWithIterateOutwards(entry, xRange, yRange, zRange);
+
+        //decrease the array size, as of now it won't be modified anymore anyways
+        entry.trim();
+
+        //this might overwrite an entry as the same entry could have been computed and added during this thread's computation
+        //we do not use computeIfAbsent, as it can delay other threads for too long
+        Object previousEntry = this.table.put(key, entry);
+
+
+        if (previousEntry == null && this.table.size() > this.capacity) {
+            //prevent a memory leak by randomly removing about 1/8th of the elements when the exceed the desired capacity is exceeded
+            final Iterator<Long> iterator = this.table.keySet().iterator();
+            //prevent an unlikely infinite loop caused by another thread filling the table concurrently using counting
+            for (int i = -this.capacity; iterator.hasNext() && i < 5; i++) {
+                Long key2 = iterator.next();
+                //random is not threadsafe, but it doesn't matter here, because we don't need quality random numbers
+                if (this.random.nextInt(8) == 0 && key2 != key) {
+                    iterator.remove();
+                }
+            }
+        }
+
+        return entry;
+    }
+}

--- a/src/main/java/me/jellysquid/mods/lithium/common/cached_blockpos_iteration/LongList2BlockPosMutableIterable.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/cached_blockpos_iteration/LongList2BlockPosMutableIterable.java
@@ -1,0 +1,47 @@
+package me.jellysquid.mods.lithium.common.cached_blockpos_iteration;
+
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.longs.LongList;
+import net.minecraft.util.math.BlockPos;
+
+import java.util.Iterator;
+
+/**
+ * @author 2No2Name
+ */
+public class LongList2BlockPosMutableIterable implements Iterable<BlockPos> {
+
+    private final LongList positions;
+    private final int xOffset, yOffset, zOffset;
+
+    public LongList2BlockPosMutableIterable(BlockPos offset, LongList posList) {
+        this.xOffset = offset.getX();
+        this.yOffset = offset.getY();
+        this.zOffset = offset.getZ();
+        this.positions = posList;
+    }
+
+    @Override
+    public Iterator<BlockPos> iterator() {
+        return new Iterator<BlockPos>() {
+
+            private final LongIterator it = LongList2BlockPosMutableIterable.this.positions.iterator();
+            private final BlockPos.Mutable pos = new BlockPos.Mutable();
+
+            @Override
+            public boolean hasNext() {
+                return it.hasNext();
+            }
+
+            @Override
+            public net.minecraft.util.math.BlockPos next() {
+                long nextPos = this.it.nextLong();
+                return this.pos.set(
+                        LongList2BlockPosMutableIterable.this.xOffset + BlockPos.unpackLongX(nextPos),
+                        LongList2BlockPosMutableIterable.this.yOffset + BlockPos.unpackLongY(nextPos),
+                        LongList2BlockPosMutableIterable.this.zOffset + BlockPos.unpackLongZ(nextPos));
+            }
+        };
+    }
+
+}

--- a/src/main/java/me/jellysquid/mods/lithium/common/config/LithiumConfig.java
+++ b/src/main/java/me/jellysquid/mods/lithium/common/config/LithiumConfig.java
@@ -47,6 +47,7 @@ public class LithiumConfig {
         this.addMixinRule("block.flatten_states", true);
         this.addMixinRule("block.piston_shapes", true);
 
+        this.addMixinRule("cached_blockpos_iteration", true);
         this.addMixinRule("cached_hashcode", true);
 
         this.addMixinRule("chunk", true);

--- a/src/main/java/me/jellysquid/mods/lithium/mixin/cached_blockpos_iteration/BlockPosMixin.java
+++ b/src/main/java/me/jellysquid/mods/lithium/mixin/cached_blockpos_iteration/BlockPosMixin.java
@@ -1,0 +1,35 @@
+package me.jellysquid.mods.lithium.mixin.cached_blockpos_iteration;
+
+import it.unimi.dsi.fastutil.longs.LongList;
+import me.jellysquid.mods.lithium.common.cached_blockpos_iteration.IterateOutwardsCache;
+import me.jellysquid.mods.lithium.common.cached_blockpos_iteration.LongList2BlockPosMutableIterable;
+import net.minecraft.util.math.BlockPos;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import static me.jellysquid.mods.lithium.common.cached_blockpos_iteration.IterateOutwardsCache.POS_ZERO;
+
+/**
+ * @author 2No2Name, original implemenation by SuperCoder7979 and Gegy1000
+ */
+@Mixin(BlockPos.class)
+public class BlockPosMixin {
+    private static final IterateOutwardsCache ITERATE_OUTWARDS_CACHE = new IterateOutwardsCache(50);
+    private static final LongList HOGLIN_PIGLIN_CACHE = ITERATE_OUTWARDS_CACHE.getOrCompute(8, 4, 8);
+
+    @Inject(method = "iterateOutwards", at = @At("HEAD"), cancellable = true)
+    private static void iterateOutwards(BlockPos center, int xRange, int yRange, int zRange, CallbackInfoReturnable<Iterable<BlockPos>> cir) {
+        if (center == POS_ZERO) {
+            //use vanilla code when we call iterateOutwards to fill the cache
+            return;
+        }
+        //use our cache when it is called from other places
+        //shortcut the most commonly used 8,4,8 range to skip map lookup
+        final LongList positions = xRange == 8 && yRange == 4 && zRange == 8 ? HOGLIN_PIGLIN_CACHE : ITERATE_OUTWARDS_CACHE.getOrCompute(xRange, yRange, zRange);
+        cir.setReturnValue(new LongList2BlockPosMutableIterable(center, positions));
+    }
+
+
+}

--- a/src/main/resources/lithium.mixins.json
+++ b/src/main/resources/lithium.mixins.json
@@ -43,6 +43,7 @@
         "block.flatten_states.AbstractBlockStateMixin",
         "block.flatten_states.FluidStateMixin",
         "block.piston_shapes.PistonHeadBlockMixin",
+        "cached_blockpos_iteration.BlockPosMixin",
         "cached_hashcode.BlockNeighborGroupMixin",
         "chunk.count_oversized_blocks.MixinChunkSection",
         "chunk.no_locking.PalettedContainerMixin",


### PR DESCRIPTION
original implementation by SuperCoder797 and Gegy1000